### PR TITLE
Allow for wrapping layer in quotes

### DIFF
--- a/src/module-parser.js
+++ b/src/module-parser.js
@@ -719,136 +719,138 @@ function peg$parse(input, options) {
       peg$c445 = function() { return { type: "placed", value: { type: "boolean", value: true }}},
       peg$c446 = "layer",
       peg$c447 = peg$literalExpectation("layer", false),
-      peg$c448 = "B.Adhes",
-      peg$c449 = peg$literalExpectation("B.Adhes", false),
-      peg$c450 = "F.Adhes",
-      peg$c451 = peg$literalExpectation("F.Adhes", false),
-      peg$c452 = "B.Paste",
-      peg$c453 = peg$literalExpectation("B.Paste", false),
-      peg$c454 = "F.Paste",
-      peg$c455 = peg$literalExpectation("F.Paste", false),
-      peg$c456 = "B.SilkS",
-      peg$c457 = peg$literalExpectation("B.SilkS", false),
-      peg$c458 = "F.SilkS",
-      peg$c459 = peg$literalExpectation("F.SilkS", false),
-      peg$c460 = "B.Mask",
-      peg$c461 = peg$literalExpectation("B.Mask", false),
-      peg$c462 = "F.Mask",
-      peg$c463 = peg$literalExpectation("F.Mask", false),
-      peg$c464 = "B.Fab",
-      peg$c465 = peg$literalExpectation("B.Fab", false),
-      peg$c466 = "F.Fab",
-      peg$c467 = peg$literalExpectation("F.Fab", false),
-      peg$c468 = "B.CrtYd",
-      peg$c469 = peg$literalExpectation("B.CrtYd", false),
-      peg$c470 = "F.CrtYd",
-      peg$c471 = peg$literalExpectation("F.CrtYd", false),
-      peg$c472 = "Dwgs.User",
-      peg$c473 = peg$literalExpectation("Dwgs.User", false),
-      peg$c474 = "Cmts.User",
-      peg$c475 = peg$literalExpectation("Cmts.User", false),
-      peg$c476 = "Eco1.User",
-      peg$c477 = peg$literalExpectation("Eco1.User", false),
-      peg$c478 = "Eco2.User",
-      peg$c479 = peg$literalExpectation("Eco2.User", false),
-      peg$c480 = "Edge.Cuts",
-      peg$c481 = peg$literalExpectation("Edge.Cuts", false),
-      peg$c482 = function(value) {
+      peg$c448 = "\"",
+      peg$c449 = peg$literalExpectation("\"", false),
+      peg$c450 = "B.Adhes",
+      peg$c451 = peg$literalExpectation("B.Adhes", false),
+      peg$c452 = "F.Adhes",
+      peg$c453 = peg$literalExpectation("F.Adhes", false),
+      peg$c454 = "B.Paste",
+      peg$c455 = peg$literalExpectation("B.Paste", false),
+      peg$c456 = "F.Paste",
+      peg$c457 = peg$literalExpectation("F.Paste", false),
+      peg$c458 = "B.SilkS",
+      peg$c459 = peg$literalExpectation("B.SilkS", false),
+      peg$c460 = "F.SilkS",
+      peg$c461 = peg$literalExpectation("F.SilkS", false),
+      peg$c462 = "B.Mask",
+      peg$c463 = peg$literalExpectation("B.Mask", false),
+      peg$c464 = "F.Mask",
+      peg$c465 = peg$literalExpectation("F.Mask", false),
+      peg$c466 = "B.Fab",
+      peg$c467 = peg$literalExpectation("B.Fab", false),
+      peg$c468 = "F.Fab",
+      peg$c469 = peg$literalExpectation("F.Fab", false),
+      peg$c470 = "B.CrtYd",
+      peg$c471 = peg$literalExpectation("B.CrtYd", false),
+      peg$c472 = "F.CrtYd",
+      peg$c473 = peg$literalExpectation("F.CrtYd", false),
+      peg$c474 = "Dwgs.User",
+      peg$c475 = peg$literalExpectation("Dwgs.User", false),
+      peg$c476 = "Cmts.User",
+      peg$c477 = peg$literalExpectation("Cmts.User", false),
+      peg$c478 = "Eco1.User",
+      peg$c479 = peg$literalExpectation("Eco1.User", false),
+      peg$c480 = "Eco2.User",
+      peg$c481 = peg$literalExpectation("Eco2.User", false),
+      peg$c482 = "Edge.Cuts",
+      peg$c483 = peg$literalExpectation("Edge.Cuts", false),
+      peg$c484 = function(value) {
               return { type: "string", value }
           },
-      peg$c483 = "tedit",
-      peg$c484 = peg$literalExpectation("tedit", false),
-      peg$c485 = function(tedit) { return { type:"tedit", value:tedit } },
-      peg$c486 = "tstamp",
-      peg$c487 = peg$literalExpectation("tstamp", false),
-      peg$c488 = function(tstamp) { // TODO: (string/symbol) is probably wrong
+      peg$c485 = "tedit",
+      peg$c486 = peg$literalExpectation("tedit", false),
+      peg$c487 = function(tedit) { return { type:"tedit", value:tedit } },
+      peg$c488 = "tstamp",
+      peg$c489 = peg$literalExpectation("tstamp", false),
+      peg$c490 = function(tstamp) { // TODO: (string/symbol) is probably wrong
           return {
               type:"tstamp",
               value:tstamp
           }
       },
-      peg$c489 = "effects",
-      peg$c490 = peg$literalExpectation("effects", false),
-      peg$c491 = function(type, effects) {
+      peg$c491 = "effects",
+      peg$c492 = peg$literalExpectation("effects", false),
+      peg$c493 = function(type, effects) {
               return { type, value: effects.map(x => x[0]) }
           },
-      peg$c492 = "font",
-      peg$c493 = peg$literalExpectation("font", false),
-      peg$c494 = function(type, attrs) {
+      peg$c494 = "font",
+      peg$c495 = peg$literalExpectation("font", false),
+      peg$c496 = function(type, attrs) {
               return {
                   type,
                   value: attrs.map(x => x[0])
               }
           },
-      peg$c495 = "bold",
-      peg$c496 = peg$literalExpectation("bold", false),
-      peg$c497 = function(type) { return { type, value: { type: "boolean", value: true } }},
-      peg$c498 = "italic",
-      peg$c499 = peg$literalExpectation("italic", false),
-      peg$c500 = "justify",
-      peg$c501 = peg$literalExpectation("justify", false),
-      peg$c502 = function(type, justify) {
+      peg$c497 = "bold",
+      peg$c498 = peg$literalExpectation("bold", false),
+      peg$c499 = function(type) { return { type, value: { type: "boolean", value: true } }},
+      peg$c500 = "italic",
+      peg$c501 = peg$literalExpectation("italic", false),
+      peg$c502 = "justify",
+      peg$c503 = peg$literalExpectation("justify", false),
+      peg$c504 = function(type, justify) {
           return { type, value: justify.map(x => x[0]) }
       },
-      peg$c503 = "left",
-      peg$c504 = peg$literalExpectation("left", false),
-      peg$c505 = "right",
-      peg$c506 = peg$literalExpectation("right", false),
-      peg$c507 = "top",
-      peg$c508 = peg$literalExpectation("top", false),
-      peg$c509 = "bottom",
-      peg$c510 = peg$literalExpectation("bottom", false),
-      peg$c511 = function(value) {
+      peg$c505 = "left",
+      peg$c506 = peg$literalExpectation("left", false),
+      peg$c507 = "right",
+      peg$c508 = peg$literalExpectation("right", false),
+      peg$c509 = "top",
+      peg$c510 = peg$literalExpectation("top", false),
+      peg$c511 = "bottom",
+      peg$c512 = peg$literalExpectation("bottom", false),
+      peg$c513 = function(value) {
               return {type:"string",value}
           },
-      peg$c512 = function(type) { return { type, value:{ type: "boolean", value: true } }},
-      peg$c513 = "descr",
-      peg$c514 = peg$literalExpectation("descr", false),
-      peg$c515 = function(type, value) {
+      peg$c514 = function(type) { return { type, value:{ type: "boolean", value: true } }},
+      peg$c515 = "descr",
+      peg$c516 = peg$literalExpectation("descr", false),
+      peg$c517 = function(type, value) {
           return { type, value } // TODO: symbols is probably wrong
           },
-      peg$c516 = "tags",
-      peg$c517 = peg$literalExpectation("tags", false),
-      peg$c518 = function(type, value) {
+      peg$c518 = "tags",
+      peg$c519 = peg$literalExpectation("tags", false),
+      peg$c520 = function(type, value) {
           return { type, value }
           },
-      peg$c519 = "path",
-      peg$c520 = peg$literalExpectation("path", false),
-      peg$c521 = "solder_paste_margin_ratio",
-      peg$c522 = peg$literalExpectation("solder_paste_margin_ratio", false),
-      peg$c523 = "solder_mask_margin",
-      peg$c524 = peg$literalExpectation("solder_mask_margin", false),
-      peg$c525 = "solder_paste_margin",
-      peg$c526 = peg$literalExpectation("solder_paste_margin", false),
-      peg$c527 = "solder_paste_ratio",
-      peg$c528 = peg$literalExpectation("solder_paste_ratio", false),
-      peg$c529 = "thermal_width",
-      peg$c530 = peg$literalExpectation("thermal_width", false),
-      peg$c531 = "zone_connect",
-      peg$c532 = peg$literalExpectation("zone_connect", false),
-      peg$c533 = "autoplace_cost90",
-      peg$c534 = peg$literalExpectation("autoplace_cost90", false),
-      peg$c535 = "autoplace_cost180",
-      peg$c536 = peg$literalExpectation("autoplace_cost180", false),
-      peg$c537 = "attr",
-      peg$c538 = peg$literalExpectation("attr", false),
-      peg$c539 = "smd",
-      peg$c540 = peg$literalExpectation("smd", false),
-      peg$c541 = "virtual",
-      peg$c542 = peg$literalExpectation("virtual", false),
-      peg$c543 = "through_hole",
-      peg$c544 = peg$literalExpectation("through_hole", false),
-      peg$c545 = function(value, tag) {return tag},
-      peg$c546 = function(value, tags) {
+      peg$c521 = "path",
+      peg$c522 = peg$literalExpectation("path", false),
+      peg$c523 = "solder_paste_margin_ratio",
+      peg$c524 = peg$literalExpectation("solder_paste_margin_ratio", false),
+      peg$c525 = "solder_mask_margin",
+      peg$c526 = peg$literalExpectation("solder_mask_margin", false),
+      peg$c527 = "solder_paste_margin",
+      peg$c528 = peg$literalExpectation("solder_paste_margin", false),
+      peg$c529 = "solder_paste_ratio",
+      peg$c530 = peg$literalExpectation("solder_paste_ratio", false),
+      peg$c531 = "thermal_width",
+      peg$c532 = peg$literalExpectation("thermal_width", false),
+      peg$c533 = "zone_connect",
+      peg$c534 = peg$literalExpectation("zone_connect", false),
+      peg$c535 = "autoplace_cost90",
+      peg$c536 = peg$literalExpectation("autoplace_cost90", false),
+      peg$c537 = "autoplace_cost180",
+      peg$c538 = peg$literalExpectation("autoplace_cost180", false),
+      peg$c539 = "attr",
+      peg$c540 = peg$literalExpectation("attr", false),
+      peg$c541 = "smd",
+      peg$c542 = peg$literalExpectation("smd", false),
+      peg$c543 = "virtual",
+      peg$c544 = peg$literalExpectation("virtual", false),
+      peg$c545 = "through_hole",
+      peg$c546 = peg$literalExpectation("through_hole", false),
+      peg$c547 = function(value, tag) {return tag},
+      peg$c548 = function(value, tags) {
               return  {
                   type: "module_attribute",
                   value: {type:"string",value},
                   tags
               }
       },
-      peg$c547 = "property",
-      peg$c548 = peg$literalExpectation("property", false),
-      peg$c549 = function(key, value) {
+      peg$c549 = "property",
+      peg$c550 = peg$literalExpectation("property", false),
+      peg$c551 = function(key, value) {
               return  {
                   type: "module_property",
                   value: [
@@ -857,13 +859,13 @@ function peg$parse(input, options) {
                   ]
               }
       },
-      peg$c550 = "fp_text",
-      peg$c551 = peg$literalExpectation("fp_text", false),
-      peg$c552 = "reference",
-      peg$c553 = peg$literalExpectation("reference", false),
-      peg$c554 = "value",
-      peg$c555 = peg$literalExpectation("value", false),
-      peg$c556 = function(type, text_type, value, at, attrs) {
+      peg$c552 = "fp_text",
+      peg$c553 = peg$literalExpectation("fp_text", false),
+      peg$c554 = "reference",
+      peg$c555 = peg$literalExpectation("reference", false),
+      peg$c556 = "value",
+      peg$c557 = peg$literalExpectation("value", false),
+      peg$c558 = function(type, text_type, value, at, attrs) {
               return {
                   type,
                   value: [
@@ -880,9 +882,9 @@ function peg$parse(input, options) {
                        ]
               }
           },
-      peg$c557 = "fp_arc",
-      peg$c558 = peg$literalExpectation("fp_arc", false),
-      peg$c559 = function(type, start, mid, end, angle, generics) {
+      peg$c559 = "fp_arc",
+      peg$c560 = peg$literalExpectation("fp_arc", false),
+      peg$c561 = function(type, start, mid, end, angle, generics) {
               const out = [start];
               if (mid !== null) {
                   out.push(mid[0]);
@@ -896,46 +898,46 @@ function peg$parse(input, options) {
                   value: [ ...out , ...generics ]
               };
           },
-      peg$c560 = "fp_circle",
-      peg$c561 = peg$literalExpectation("fp_circle", false),
-      peg$c562 = function(type, center, end, generics) {
+      peg$c562 = "fp_circle",
+      peg$c563 = peg$literalExpectation("fp_circle", false),
+      peg$c564 = function(type, center, end, generics) {
               return {
                   type,
                   value: [ center, end, ...generics ]
               };
           },
-      peg$c563 = "fp_curve",
-      peg$c564 = peg$literalExpectation("fp_curve", false),
-      peg$c565 = function(type, pts, generics) {
+      peg$c565 = "fp_curve",
+      peg$c566 = peg$literalExpectation("fp_curve", false),
+      peg$c567 = function(type, pts, generics) {
               return {
                   type,
                   value:[ ...pts, ...generics ]
               };
           },
-      peg$c566 = "fp_line",
-      peg$c567 = peg$literalExpectation("fp_line", false),
-      peg$c568 = function(type, start, end, generics) {
+      peg$c568 = "fp_line",
+      peg$c569 = peg$literalExpectation("fp_line", false),
+      peg$c570 = function(type, start, end, generics) {
               return {
                   type,
                   value: [ start, end, ...generics ]
               };
           },
-      peg$c569 = "fp_rect",
-      peg$c570 = peg$literalExpectation("fp_rect", false),
-      peg$c571 = "fp_poly",
-      peg$c572 = peg$literalExpectation("fp_poly", false),
-      peg$c573 = function(type, pts, generics) {
+      peg$c571 = "fp_rect",
+      peg$c572 = peg$literalExpectation("fp_rect", false),
+      peg$c573 = "fp_poly",
+      peg$c574 = peg$literalExpectation("fp_poly", false),
+      peg$c575 = function(type, pts, generics) {
               return {
                   type,
                   value: [ pts , ...generics ]
               };
           },
-      peg$c574 = function(generics) {
+      peg$c576 = function(generics) {
               return generics.map(x => x[0])
           },
-      peg$c575 = "pad",
-      peg$c576 = peg$literalExpectation("pad", false),
-      peg$c577 = function(no, pad_type, shape, attrs) {
+      peg$c577 = "pad",
+      peg$c578 = peg$literalExpectation("pad", false),
+      peg$c579 = function(no, pad_type, shape, attrs) {
               return {
                   type: "pad",
                   value: [
@@ -946,45 +948,45 @@ function peg$parse(input, options) {
                   ]
               }
           },
-      peg$c578 = "thru_hole",
-      peg$c579 = peg$literalExpectation("thru_hole", false),
-      peg$c580 = "np_thru_hole",
-      peg$c581 = peg$literalExpectation("np_thru_hole", false),
-      peg$c582 = "connect",
-      peg$c583 = peg$literalExpectation("connect", false),
-      peg$c584 = function(value) {
+      peg$c580 = "thru_hole",
+      peg$c581 = peg$literalExpectation("thru_hole", false),
+      peg$c582 = "np_thru_hole",
+      peg$c583 = peg$literalExpectation("np_thru_hole", false),
+      peg$c584 = "connect",
+      peg$c585 = peg$literalExpectation("connect", false),
+      peg$c586 = function(value) {
                return { type: "pad_type", value: { type: "string", value } }
           },
-      peg$c585 = "circle",
-      peg$c586 = peg$literalExpectation("circle", false),
-      peg$c587 = "rect",
-      peg$c588 = peg$literalExpectation("rect", false),
-      peg$c589 = "oval",
-      peg$c590 = peg$literalExpectation("oval", false),
-      peg$c591 = "trapezoid",
-      peg$c592 = peg$literalExpectation("trapezoid", false),
-      peg$c593 = "roundrect",
-      peg$c594 = peg$literalExpectation("roundrect", false),
-      peg$c595 = "custom",
-      peg$c596 = peg$literalExpectation("custom", false),
-      peg$c597 = function(value) {
+      peg$c587 = "circle",
+      peg$c588 = peg$literalExpectation("circle", false),
+      peg$c589 = "rect",
+      peg$c590 = peg$literalExpectation("rect", false),
+      peg$c591 = "oval",
+      peg$c592 = peg$literalExpectation("oval", false),
+      peg$c593 = "trapezoid",
+      peg$c594 = peg$literalExpectation("trapezoid", false),
+      peg$c595 = "roundrect",
+      peg$c596 = peg$literalExpectation("roundrect", false),
+      peg$c597 = "custom",
+      peg$c598 = peg$literalExpectation("custom", false),
+      peg$c599 = function(value) {
               return { type: "pad_shape", value: { type: "string", value } }
           },
-      peg$c598 = "top_left",
-      peg$c599 = peg$literalExpectation("top_left", false),
-      peg$c600 = "top_right",
-      peg$c601 = peg$literalExpectation("top_right", false),
-      peg$c602 = "bottom_left",
-      peg$c603 = peg$literalExpectation("bottom_left", false),
-      peg$c604 = "bottom_right",
-      peg$c605 = peg$literalExpectation("bottom_right", false),
-      peg$c606 = function(type, value) {return { type: "string", value }},
-      peg$c607 = function(type, value) {
+      peg$c600 = "top_left",
+      peg$c601 = peg$literalExpectation("top_left", false),
+      peg$c602 = "top_right",
+      peg$c603 = peg$literalExpectation("top_right", false),
+      peg$c604 = "bottom_left",
+      peg$c605 = peg$literalExpectation("bottom_left", false),
+      peg$c606 = "bottom_right",
+      peg$c607 = peg$literalExpectation("bottom_right", false),
+      peg$c608 = function(type, value) {return { type: "string", value }},
+      peg$c609 = function(type, value) {
               return {type,value}
           },
-      peg$c608 = "size",
-      peg$c609 = peg$literalExpectation("size", false),
-      peg$c610 = function(type, width, height) {
+      peg$c610 = "size",
+      peg$c611 = peg$literalExpectation("size", false),
+      peg$c612 = function(type, width, height) {
               return {
                  type,
                   value:  [
@@ -993,11 +995,11 @@ function peg$parse(input, options) {
                       ]
                   }
           },
-      peg$c611 = "at",
-      peg$c612 = peg$literalExpectation("at", false),
-      peg$c613 = "unlocked",
-      peg$c614 = peg$literalExpectation("unlocked", false),
-      peg$c615 = function(type, x, y, angle, unlocked) {
+      peg$c613 = "at",
+      peg$c614 = peg$literalExpectation("at", false),
+      peg$c615 = "unlocked",
+      peg$c616 = peg$literalExpectation("unlocked", false),
+      peg$c617 = function(type, x, y, angle, unlocked) {
               var value = [
                   { type: "x", value:x },
                   { type: "y", value:y },
@@ -1006,9 +1008,9 @@ function peg$parse(input, options) {
               if(angle !== null) value.push( { type: "angle", value:angle[0] } )
               return { type, value }
           },
-      peg$c616 = "rect_delta",
-      peg$c617 = peg$literalExpectation("rect_delta", false),
-      peg$c618 = function(type, width, height) {
+      peg$c618 = "rect_delta",
+      peg$c619 = peg$literalExpectation("rect_delta", false),
+      peg$c620 = function(type, width, height) {
               return {
                       type,
                       value: [
@@ -1017,7 +1019,7 @@ function peg$parse(input, options) {
                           ]
                       }
           },
-      peg$c619 = function(type, attrs) {
+      peg$c621 = function(type, attrs) {
 
               var height,width
               var value = []
@@ -1042,10 +1044,10 @@ function peg$parse(input, options) {
               return { type, value }
 
           },
-      peg$c620 = function(type) { return { type, value: { type: "boolean", value: true } } },
-      peg$c621 = "offset",
-      peg$c622 = peg$literalExpectation("offset", false),
-      peg$c623 = function(type, x, y) {
+      peg$c622 = function(type) { return { type, value: { type: "boolean", value: true } } },
+      peg$c623 = "offset",
+      peg$c624 = peg$literalExpectation("offset", false),
+      peg$c625 = function(type, x, y) {
           return {
               type,
               value: [
@@ -1055,45 +1057,45 @@ function peg$parse(input, options) {
           }
 
       },
-      peg$c624 = function(type, val) {return val},
-      peg$c625 = "chamfer_ratio",
-      peg$c626 = peg$literalExpectation("chamfer_ratio", false),
-      peg$c627 = "roundrect_rratio",
-      peg$c628 = peg$literalExpectation("roundrect_rratio", false),
-      peg$c629 = "die_length",
-      peg$c630 = peg$literalExpectation("die_length", false),
-      peg$c631 = "options",
-      peg$c632 = peg$literalExpectation("options", false),
-      peg$c633 = "anchor",
-      peg$c634 = peg$literalExpectation("anchor", false),
-      peg$c635 = function(type, value) {
+      peg$c626 = function(type, val) {return val},
+      peg$c627 = "chamfer_ratio",
+      peg$c628 = peg$literalExpectation("chamfer_ratio", false),
+      peg$c629 = "roundrect_rratio",
+      peg$c630 = peg$literalExpectation("roundrect_rratio", false),
+      peg$c631 = "die_length",
+      peg$c632 = peg$literalExpectation("die_length", false),
+      peg$c633 = "options",
+      peg$c634 = peg$literalExpectation("options", false),
+      peg$c635 = "anchor",
+      peg$c636 = peg$literalExpectation("anchor", false),
+      peg$c637 = function(type, value) {
               return { type, value: { type: "string", value: value}}
           },
-      peg$c636 = "outline",
-      peg$c637 = peg$literalExpectation("outline", false),
-      peg$c638 = "convexhull",
-      peg$c639 = peg$literalExpectation("convexhull", false),
-      peg$c640 = function(type, value) {
+      peg$c638 = "outline",
+      peg$c639 = peg$literalExpectation("outline", false),
+      peg$c640 = "convexhull",
+      peg$c641 = peg$literalExpectation("convexhull", false),
+      peg$c642 = function(type, value) {
               return { type, value: { type: "string", value } }
           },
-      peg$c641 = "primitives",
-      peg$c642 = peg$literalExpectation("primitives", false),
-      peg$c643 = function(type, val) { return val },
-      peg$c644 = "gr_arc",
-      peg$c645 = peg$literalExpectation("gr_arc", false),
-      peg$c646 = function(type, center, end, generics) {
+      peg$c643 = "primitives",
+      peg$c644 = peg$literalExpectation("primitives", false),
+      peg$c645 = function(type, val) { return val },
+      peg$c646 = "gr_arc",
+      peg$c647 = peg$literalExpectation("gr_arc", false),
+      peg$c648 = function(type, center, end, generics) {
               return {
                   type,
                   value:[ center, end, ...generics ]
               };
           },
-      peg$c647 = "gr_circle",
-      peg$c648 = peg$literalExpectation("gr_circle", false),
-      peg$c649 = "gr_curve",
-      peg$c650 = peg$literalExpectation("gr_curve", false),
-      peg$c651 = "pts",
-      peg$c652 = peg$literalExpectation("pts", false),
-      peg$c653 = function(start, control1, control2, end) {
+      peg$c649 = "gr_circle",
+      peg$c650 = peg$literalExpectation("gr_circle", false),
+      peg$c651 = "gr_curve",
+      peg$c652 = peg$literalExpectation("gr_curve", false),
+      peg$c653 = "pts",
+      peg$c654 = peg$literalExpectation("pts", false),
+      peg$c655 = function(start, control1, control2, end) {
               // console.log("start", start)
               // console.log("control1", control1)
               // console.log("control2", control2)
@@ -1112,27 +1114,27 @@ function peg$parse(input, options) {
                       { type:"end", value: end.value },
                   ]
           },
-      peg$c654 = "gr_line",
-      peg$c655 = peg$literalExpectation("gr_line", false),
-      peg$c656 = function(type, start, end, generics) {
+      peg$c656 = "gr_line",
+      peg$c657 = peg$literalExpectation("gr_line", false),
+      peg$c658 = function(type, start, end, generics) {
               return {
                   type,
                   value:[ start, end, ...generics ]
               };
           },
-      peg$c657 = "gr_rect",
-      peg$c658 = peg$literalExpectation("gr_rect", false),
-      peg$c659 = "gr_poly",
-      peg$c660 = peg$literalExpectation("gr_poly", false),
-      peg$c661 = function(type, pts, generics) {
+      peg$c659 = "gr_rect",
+      peg$c660 = peg$literalExpectation("gr_rect", false),
+      peg$c661 = "gr_poly",
+      peg$c662 = peg$literalExpectation("gr_poly", false),
+      peg$c663 = function(type, pts, generics) {
               return {
                   type,
                   value: [ pts, ...generics ]
               };
           },
-      peg$c662 = "gr_text",
-      peg$c663 = peg$literalExpectation("gr_text", false),
-      peg$c664 = function(type, text, at, options) {
+      peg$c664 = "gr_text",
+      peg$c665 = peg$literalExpectation("gr_text", false),
+      peg$c666 = function(type, text, at, options) {
 
            const value  = [
                {type: "text", value: text},
@@ -1142,11 +1144,11 @@ function peg$parse(input, options) {
            return {type, value}
 
       },
-      peg$c665 = "status",
-      peg$c666 = peg$literalExpectation("status", false),
-      peg$c667 = "stroke",
-      peg$c668 = peg$literalExpectation("stroke", false),
-      peg$c669 = function(type, width, stroke_type) {
+      peg$c667 = "status",
+      peg$c668 = peg$literalExpectation("status", false),
+      peg$c669 = "stroke",
+      peg$c670 = peg$literalExpectation("stroke", false),
+      peg$c671 = function(type, width, stroke_type) {
               return { type,
                       value:
                       [
@@ -1155,53 +1157,53 @@ function peg$parse(input, options) {
                       ]
                }
           },
-      peg$c670 = "type",
-      peg$c671 = peg$literalExpectation("type", false),
-      peg$c672 = "dash",
-      peg$c673 = peg$literalExpectation("dash", false),
-      peg$c674 = "dash_dot",
-      peg$c675 = peg$literalExpectation("dash_dot", false),
-      peg$c676 = "dash_dot_dot",
-      peg$c677 = peg$literalExpectation("dash_dot_dot", false),
-      peg$c678 = "dot",
-      peg$c679 = peg$literalExpectation("dot", false),
-      peg$c680 = "default",
-      peg$c681 = peg$literalExpectation("default", false),
-      peg$c682 = "solid",
-      peg$c683 = peg$literalExpectation("solid", false),
-      peg$c684 = function(value) {
+      peg$c672 = "type",
+      peg$c673 = peg$literalExpectation("type", false),
+      peg$c674 = "dash",
+      peg$c675 = peg$literalExpectation("dash", false),
+      peg$c676 = "dash_dot",
+      peg$c677 = peg$literalExpectation("dash_dot", false),
+      peg$c678 = "dash_dot_dot",
+      peg$c679 = peg$literalExpectation("dash_dot_dot", false),
+      peg$c680 = "dot",
+      peg$c681 = peg$literalExpectation("dot", false),
+      peg$c682 = "default",
+      peg$c683 = peg$literalExpectation("default", false),
+      peg$c684 = "solid",
+      peg$c685 = peg$literalExpectation("solid", false),
+      peg$c686 = function(value) {
               return { type: "string", value}
           },
-      peg$c685 = "width",
-      peg$c686 = peg$literalExpectation("width", false),
-      peg$c687 = "angle",
-      peg$c688 = peg$literalExpectation("angle", false),
-      peg$c689 = "mid",
-      peg$c690 = peg$literalExpectation("mid", false),
-      peg$c691 = "start",
-      peg$c692 = peg$literalExpectation("start", false),
-      peg$c693 = function(x, y) {
+      peg$c687 = "width",
+      peg$c688 = peg$literalExpectation("width", false),
+      peg$c689 = "angle",
+      peg$c690 = peg$literalExpectation("angle", false),
+      peg$c691 = "mid",
+      peg$c692 = peg$literalExpectation("mid", false),
+      peg$c693 = "start",
+      peg$c694 = peg$literalExpectation("start", false),
+      peg$c695 = function(x, y) {
             return [
                       {type: "x", value:x},
                       {type: "y", value:y},
                   ]
 
         },
-      peg$c694 = "center",
-      peg$c695 = peg$literalExpectation("center", false),
-      peg$c696 = function(type, value) {
+      peg$c696 = "center",
+      peg$c697 = peg$literalExpectation("center", false),
+      peg$c698 = function(type, value) {
               return { type, value } // yep, "center"
       },
-      peg$c697 = "end",
-      peg$c698 = peg$literalExpectation("end", false),
-      peg$c699 = function(type, pts) {
+      peg$c699 = "end",
+      peg$c700 = peg$literalExpectation("end", false),
+      peg$c701 = function(type, pts) {
               return { type, value: pts.map(x => x[0])}
           },
-      peg$c700 = "xy",
-      peg$c701 = peg$literalExpectation("xy", false),
-      peg$c702 = "model",
-      peg$c703 = peg$literalExpectation("model", false),
-      peg$c704 = function(type, filename, attr) {
+      peg$c702 = "xy",
+      peg$c703 = peg$literalExpectation("xy", false),
+      peg$c704 = "model",
+      peg$c705 = peg$literalExpectation("model", false),
+      peg$c706 = function(type, filename, attr) {
               return {
                   type,
                   value: [
@@ -1210,27 +1212,25 @@ function peg$parse(input, options) {
                   ]
               }
           },
-      peg$c705 = "opacity",
-      peg$c706 = peg$literalExpectation("opacity", false),
-      peg$c707 = function(value) { return { type:"opacity", value:value } },
-      peg$c708 = "scale",
-      peg$c709 = peg$literalExpectation("scale", false),
-      peg$c710 = "rotate",
-      peg$c711 = peg$literalExpectation("rotate", false),
-      peg$c712 = function(type, value) {
+      peg$c707 = "opacity",
+      peg$c708 = peg$literalExpectation("opacity", false),
+      peg$c709 = function(value) { return { type:"opacity", value:value } },
+      peg$c710 = "scale",
+      peg$c711 = peg$literalExpectation("scale", false),
+      peg$c712 = "rotate",
+      peg$c713 = peg$literalExpectation("rotate", false),
+      peg$c714 = function(type, value) {
               return { type, value: [ value ]  }
           },
-      peg$c713 = "xyz",
-      peg$c714 = peg$literalExpectation("xyz", false),
-      peg$c715 = function(type, x, y, z) {
+      peg$c715 = "xyz",
+      peg$c716 = peg$literalExpectation("xyz", false),
+      peg$c717 = function(type, x, y, z) {
                   return { type, value:[
                       {type: "x", value:x},
                       {type: "y", value:y},
                       {type: "z", value:z}
                   ] }
               },
-      peg$c716 = "\"",
-      peg$c717 = peg$literalExpectation("\"", false),
       peg$c718 = function(chars) { return {type:"string",value:chars.join('')}; },
       peg$c719 = "'",
       peg$c720 = peg$literalExpectation("'", false),
@@ -1275,11 +1275,10 @@ function peg$parse(input, options) {
                   value: [ value, ...values.map(x => x[0])]
               }
           },
-      peg$c752 = /^[^ ();'\n]/,
-      peg$c753 = peg$classExpectation([" ", "(", ")", ";", "'", "\n"], true, false),
+      peg$c752 = /^[^ ();'"\n]/,
+      peg$c753 = peg$classExpectation([" ", "(", ")", ";", "'", "\"", "\n"], true, false),
       peg$c754 = function(value) {
-             return {type:"string",value}
-
+             return { type:"string", value: "SYM" + value }
          },
       peg$c755 = peg$otherExpectation("whitespace"),
       peg$c756 = /^[ \t\n\r]/,
@@ -8519,7 +8518,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parselayer() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
@@ -8542,24 +8541,54 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseLAYER();
+            if (input.charCodeAt(peg$currPos) === 34) {
+              s5 = peg$c448;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c449); }
+            }
             if (s5 === peg$FAILED) {
-              s5 = peg$parsesymbol();
+              s5 = null;
             }
             if (s5 !== peg$FAILED) {
-              s6 = peg$parse_();
+              s6 = peg$parseLAYER();
+              if (s6 === peg$FAILED) {
+                s6 = peg$parsesymbol();
+              }
               if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c5;
+                if (input.charCodeAt(peg$currPos) === 34) {
+                  s7 = peg$c448;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c449); }
+                }
+                if (s7 === peg$FAILED) {
+                  s7 = null;
                 }
                 if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c346(s3, s5);
-                  s0 = s1;
+                  s8 = peg$parse_();
+                  if (s8 !== peg$FAILED) {
+                    if (input.charCodeAt(peg$currPos) === 41) {
+                      s9 = peg$c5;
+                      peg$currPos++;
+                    } else {
+                      s9 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                    }
+                    if (s9 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c346(s3, s6);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -8596,140 +8625,140 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7) === peg$c448) {
-      s1 = peg$c448;
+    if (input.substr(peg$currPos, 7) === peg$c450) {
+      s1 = peg$c450;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c449); }
+      if (peg$silentFails === 0) { peg$fail(peg$c451); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 7) === peg$c450) {
-        s1 = peg$c450;
+      if (input.substr(peg$currPos, 7) === peg$c452) {
+        s1 = peg$c452;
         peg$currPos += 7;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c451); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c452) {
-          s1 = peg$c452;
+        if (input.substr(peg$currPos, 7) === peg$c454) {
+          s1 = peg$c454;
           peg$currPos += 7;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c453); }
+          if (peg$silentFails === 0) { peg$fail(peg$c455); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c454) {
-            s1 = peg$c454;
+          if (input.substr(peg$currPos, 7) === peg$c456) {
+            s1 = peg$c456;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c455); }
+            if (peg$silentFails === 0) { peg$fail(peg$c457); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 7) === peg$c456) {
-              s1 = peg$c456;
+            if (input.substr(peg$currPos, 7) === peg$c458) {
+              s1 = peg$c458;
               peg$currPos += 7;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c457); }
+              if (peg$silentFails === 0) { peg$fail(peg$c459); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 7) === peg$c458) {
-                s1 = peg$c458;
+              if (input.substr(peg$currPos, 7) === peg$c460) {
+                s1 = peg$c460;
                 peg$currPos += 7;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c459); }
+                if (peg$silentFails === 0) { peg$fail(peg$c461); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 6) === peg$c460) {
-                  s1 = peg$c460;
+                if (input.substr(peg$currPos, 6) === peg$c462) {
+                  s1 = peg$c462;
                   peg$currPos += 6;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c461); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c463); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 6) === peg$c462) {
-                    s1 = peg$c462;
+                  if (input.substr(peg$currPos, 6) === peg$c464) {
+                    s1 = peg$c464;
                     peg$currPos += 6;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c463); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c465); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c464) {
-                      s1 = peg$c464;
+                    if (input.substr(peg$currPos, 5) === peg$c466) {
+                      s1 = peg$c466;
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c465); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c467); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 5) === peg$c466) {
-                        s1 = peg$c466;
+                      if (input.substr(peg$currPos, 5) === peg$c468) {
+                        s1 = peg$c468;
                         peg$currPos += 5;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c467); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c469); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c468) {
-                          s1 = peg$c468;
+                        if (input.substr(peg$currPos, 7) === peg$c470) {
+                          s1 = peg$c470;
                           peg$currPos += 7;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c469); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c471); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c470) {
-                            s1 = peg$c470;
+                          if (input.substr(peg$currPos, 7) === peg$c472) {
+                            s1 = peg$c472;
                             peg$currPos += 7;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c471); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c473); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 9) === peg$c472) {
-                              s1 = peg$c472;
+                            if (input.substr(peg$currPos, 9) === peg$c474) {
+                              s1 = peg$c474;
                               peg$currPos += 9;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c473); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c475); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 9) === peg$c474) {
-                                s1 = peg$c474;
+                              if (input.substr(peg$currPos, 9) === peg$c476) {
+                                s1 = peg$c476;
                                 peg$currPos += 9;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c475); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c477); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 9) === peg$c476) {
-                                  s1 = peg$c476;
+                                if (input.substr(peg$currPos, 9) === peg$c478) {
+                                  s1 = peg$c478;
                                   peg$currPos += 9;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c477); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c479); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 9) === peg$c478) {
-                                    s1 = peg$c478;
+                                  if (input.substr(peg$currPos, 9) === peg$c480) {
+                                    s1 = peg$c480;
                                     peg$currPos += 9;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c479); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c481); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 9) === peg$c480) {
-                                      s1 = peg$c480;
+                                    if (input.substr(peg$currPos, 9) === peg$c482) {
+                                      s1 = peg$c482;
                                       peg$currPos += 9;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c481); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c483); }
                                     }
                                   }
                                 }
@@ -8749,7 +8778,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c482(s1);
+      s1 = peg$c484(s1);
     }
     s0 = s1;
 
@@ -8781,12 +8810,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c483) {
-          s3 = peg$c483;
+        if (input.substr(peg$currPos, 5) === peg$c485) {
+          s3 = peg$c485;
           peg$currPos += 5;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c484); }
+          if (peg$silentFails === 0) { peg$fail(peg$c486); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -8804,7 +8833,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c485(s5);
+                  s1 = peg$c487(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8852,12 +8881,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c486) {
-          s3 = peg$c486;
+        if (input.substr(peg$currPos, 6) === peg$c488) {
+          s3 = peg$c488;
           peg$currPos += 6;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c487); }
+          if (peg$silentFails === 0) { peg$fail(peg$c489); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -8878,7 +8907,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c488(s5);
+                  s1 = peg$c490(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8926,12 +8955,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c489) {
-          s3 = peg$c489;
+        if (input.substr(peg$currPos, 7) === peg$c491) {
+          s3 = peg$c491;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c490); }
+          if (peg$silentFails === 0) { peg$fail(peg$c492); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -8992,7 +9021,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c491(s3, s5);
+                s1 = peg$c493(s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9036,12 +9065,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c492) {
-          s3 = peg$c492;
+        if (input.substr(peg$currPos, 4) === peg$c494) {
+          s3 = peg$c494;
           peg$currPos += 4;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c493); }
+          if (peg$silentFails === 0) { peg$fail(peg$c495); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -9108,7 +9137,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c494(s3, s5);
+                s1 = peg$c496(s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9213,16 +9242,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c495) {
-      s1 = peg$c495;
+    if (input.substr(peg$currPos, 4) === peg$c497) {
+      s1 = peg$c497;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c496); }
+      if (peg$silentFails === 0) { peg$fail(peg$c498); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c497(s1);
+      s1 = peg$c499(s1);
     }
     s0 = s1;
 
@@ -9233,16 +9262,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c498) {
-      s1 = peg$c498;
+    if (input.substr(peg$currPos, 6) === peg$c500) {
+      s1 = peg$c500;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c499); }
+      if (peg$silentFails === 0) { peg$fail(peg$c501); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c497(s1);
+      s1 = peg$c499(s1);
     }
     s0 = s1;
 
@@ -9263,12 +9292,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c500) {
-          s3 = peg$c500;
+        if (input.substr(peg$currPos, 7) === peg$c502) {
+          s3 = peg$c502;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c501); }
+          if (peg$silentFails === 0) { peg$fail(peg$c503); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -9317,7 +9346,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c502(s3, s5);
+                s1 = peg$c504(s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9351,36 +9380,36 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c503) {
-      s1 = peg$c503;
+    if (input.substr(peg$currPos, 4) === peg$c505) {
+      s1 = peg$c505;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c504); }
+      if (peg$silentFails === 0) { peg$fail(peg$c506); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c505) {
-        s1 = peg$c505;
+      if (input.substr(peg$currPos, 5) === peg$c507) {
+        s1 = peg$c507;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c506); }
+        if (peg$silentFails === 0) { peg$fail(peg$c508); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c507) {
-          s1 = peg$c507;
+        if (input.substr(peg$currPos, 3) === peg$c509) {
+          s1 = peg$c509;
           peg$currPos += 3;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c508); }
+          if (peg$silentFails === 0) { peg$fail(peg$c510); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c509) {
-            s1 = peg$c509;
+          if (input.substr(peg$currPos, 6) === peg$c511) {
+            s1 = peg$c511;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c510); }
+            if (peg$silentFails === 0) { peg$fail(peg$c512); }
           }
           if (s1 === peg$FAILED) {
             if (input.substr(peg$currPos, 6) === peg$c269) {
@@ -9396,7 +9425,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c511(s1);
+      s1 = peg$c513(s1);
     }
     s0 = s1;
 
@@ -9416,7 +9445,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c512(s1);
+      s1 = peg$c514(s1);
     }
     s0 = s1;
 
@@ -9437,12 +9466,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c513) {
-          s3 = peg$c513;
+        if (input.substr(peg$currPos, 5) === peg$c515) {
+          s3 = peg$c515;
           peg$currPos += 5;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c514); }
+          if (peg$silentFails === 0) { peg$fail(peg$c516); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -9463,7 +9492,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c515(s3, s5);
+                  s1 = peg$c517(s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9511,12 +9540,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c516) {
-          s3 = peg$c516;
+        if (input.substr(peg$currPos, 4) === peg$c518) {
+          s3 = peg$c518;
           peg$currPos += 4;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c517); }
+          if (peg$silentFails === 0) { peg$fail(peg$c519); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -9543,7 +9572,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c518(s3, s5);
+                  s1 = peg$c520(s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9591,12 +9620,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c519) {
-          s3 = peg$c519;
+        if (input.substr(peg$currPos, 4) === peg$c521) {
+          s3 = peg$c521;
           peg$currPos += 4;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c520); }
+          if (peg$silentFails === 0) { peg$fail(peg$c522); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -9620,7 +9649,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c518(s3, s5);
+                  s1 = peg$c520(s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9722,44 +9751,44 @@ function peg$parse(input, options) {
   function peg$parseCOMMON_NUMERIC() {
     var s0;
 
-    if (input.substr(peg$currPos, 25) === peg$c521) {
-      s0 = peg$c521;
+    if (input.substr(peg$currPos, 25) === peg$c523) {
+      s0 = peg$c523;
       peg$currPos += 25;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c522); }
+      if (peg$silentFails === 0) { peg$fail(peg$c524); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 18) === peg$c523) {
-        s0 = peg$c523;
+      if (input.substr(peg$currPos, 18) === peg$c525) {
+        s0 = peg$c525;
         peg$currPos += 18;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c524); }
+        if (peg$silentFails === 0) { peg$fail(peg$c526); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 19) === peg$c525) {
-          s0 = peg$c525;
+        if (input.substr(peg$currPos, 19) === peg$c527) {
+          s0 = peg$c527;
           peg$currPos += 19;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c526); }
+          if (peg$silentFails === 0) { peg$fail(peg$c528); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 18) === peg$c527) {
-            s0 = peg$c527;
+          if (input.substr(peg$currPos, 18) === peg$c529) {
+            s0 = peg$c529;
             peg$currPos += 18;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c528); }
+            if (peg$silentFails === 0) { peg$fail(peg$c530); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 13) === peg$c529) {
-              s0 = peg$c529;
+            if (input.substr(peg$currPos, 13) === peg$c531) {
+              s0 = peg$c531;
               peg$currPos += 13;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c530); }
+              if (peg$silentFails === 0) { peg$fail(peg$c532); }
             }
             if (s0 === peg$FAILED) {
               if (input.substr(peg$currPos, 9) === peg$c289) {
@@ -9855,28 +9884,28 @@ function peg$parse(input, options) {
   function peg$parseCOMMON_INT() {
     var s0;
 
-    if (input.substr(peg$currPos, 12) === peg$c531) {
-      s0 = peg$c531;
+    if (input.substr(peg$currPos, 12) === peg$c533) {
+      s0 = peg$c533;
       peg$currPos += 12;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c532); }
+      if (peg$silentFails === 0) { peg$fail(peg$c534); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 16) === peg$c533) {
-        s0 = peg$c533;
+      if (input.substr(peg$currPos, 16) === peg$c535) {
+        s0 = peg$c535;
         peg$currPos += 16;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c534); }
+        if (peg$silentFails === 0) { peg$fail(peg$c536); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 17) === peg$c535) {
-          s0 = peg$c535;
+        if (input.substr(peg$currPos, 17) === peg$c537) {
+          s0 = peg$c537;
           peg$currPos += 17;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c536); }
+          if (peg$silentFails === 0) { peg$fail(peg$c538); }
         }
       }
     }
@@ -9898,38 +9927,38 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c537) {
-          s3 = peg$c537;
+        if (input.substr(peg$currPos, 4) === peg$c539) {
+          s3 = peg$c539;
           peg$currPos += 4;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c538); }
+          if (peg$silentFails === 0) { peg$fail(peg$c540); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 3) === peg$c539) {
-              s5 = peg$c539;
+            if (input.substr(peg$currPos, 3) === peg$c541) {
+              s5 = peg$c541;
               peg$currPos += 3;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c540); }
+              if (peg$silentFails === 0) { peg$fail(peg$c542); }
             }
             if (s5 === peg$FAILED) {
-              if (input.substr(peg$currPos, 7) === peg$c541) {
-                s5 = peg$c541;
+              if (input.substr(peg$currPos, 7) === peg$c543) {
+                s5 = peg$c543;
                 peg$currPos += 7;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c542); }
+                if (peg$silentFails === 0) { peg$fail(peg$c544); }
               }
               if (s5 === peg$FAILED) {
-                if (input.substr(peg$currPos, 12) === peg$c543) {
-                  s5 = peg$c543;
+                if (input.substr(peg$currPos, 12) === peg$c545) {
+                  s5 = peg$c545;
                   peg$currPos += 12;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c544); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c546); }
                 }
               }
             }
@@ -9952,7 +9981,7 @@ function peg$parse(input, options) {
                   s10 = peg$parse_();
                   if (s10 !== peg$FAILED) {
                     peg$savedPos = s8;
-                    s9 = peg$c545(s5, s9);
+                    s9 = peg$c547(s5, s9);
                     s8 = s9;
                   } else {
                     peg$currPos = s8;
@@ -9979,7 +10008,7 @@ function peg$parse(input, options) {
                     s10 = peg$parse_();
                     if (s10 !== peg$FAILED) {
                       peg$savedPos = s8;
-                      s9 = peg$c545(s5, s9);
+                      s9 = peg$c547(s5, s9);
                       s8 = s9;
                     } else {
                       peg$currPos = s8;
@@ -10000,7 +10029,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c546(s5, s7);
+                    s1 = peg$c548(s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10052,12 +10081,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c547) {
-          s3 = peg$c547;
+        if (input.substr(peg$currPos, 8) === peg$c549) {
+          s3 = peg$c549;
           peg$currPos += 8;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c548); }
+          if (peg$silentFails === 0) { peg$fail(peg$c550); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -10077,7 +10106,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c549(s5, s7);
+                    s1 = peg$c551(s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10129,30 +10158,30 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c550) {
-          s3 = peg$c550;
+        if (input.substr(peg$currPos, 7) === peg$c552) {
+          s3 = peg$c552;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c551); }
+          if (peg$silentFails === 0) { peg$fail(peg$c553); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 9) === peg$c552) {
-              s5 = peg$c552;
+            if (input.substr(peg$currPos, 9) === peg$c554) {
+              s5 = peg$c554;
               peg$currPos += 9;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c553); }
+              if (peg$silentFails === 0) { peg$fail(peg$c555); }
             }
             if (s5 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c554) {
-                s5 = peg$c554;
+              if (input.substr(peg$currPos, 5) === peg$c556) {
+                s5 = peg$c556;
                 peg$currPos += 5;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c555); }
+                if (peg$silentFails === 0) { peg$fail(peg$c557); }
               }
               if (s5 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c77) {
@@ -10246,7 +10275,7 @@ function peg$parse(input, options) {
                           }
                           if (s12 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c556(s3, s5, s7, s9, s11);
+                            s1 = peg$c558(s3, s5, s7, s9, s11);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10314,12 +10343,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c557) {
-          s3 = peg$c557;
+        if (input.substr(peg$currPos, 6) === peg$c559) {
+          s3 = peg$c559;
           peg$currPos += 6;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c558); }
+          if (peg$silentFails === 0) { peg$fail(peg$c560); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -10381,7 +10410,7 @@ function peg$parse(input, options) {
                           }
                           if (s12 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c559(s3, s5, s7, s8, s10, s11);
+                            s1 = peg$c561(s3, s5, s7, s8, s10, s11);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -10449,12 +10478,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c560) {
-          s3 = peg$c560;
+        if (input.substr(peg$currPos, 9) === peg$c562) {
+          s3 = peg$c562;
           peg$currPos += 9;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c561); }
+          if (peg$silentFails === 0) { peg$fail(peg$c563); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -10480,7 +10509,7 @@ function peg$parse(input, options) {
                         }
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c562(s3, s5, s7, s9);
+                          s1 = peg$c564(s3, s5, s7, s9);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -10544,12 +10573,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c563) {
-          s3 = peg$c563;
+        if (input.substr(peg$currPos, 8) === peg$c565) {
+          s3 = peg$c565;
           peg$currPos += 8;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c564); }
+          if (peg$silentFails === 0) { peg$fail(peg$c566); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -10569,7 +10598,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c565(s3, s5, s7);
+                    s1 = peg$c567(s3, s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10621,12 +10650,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c566) {
-          s3 = peg$c566;
+        if (input.substr(peg$currPos, 7) === peg$c568) {
+          s3 = peg$c568;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c567); }
+          if (peg$silentFails === 0) { peg$fail(peg$c569); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -10650,7 +10679,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c568(s3, s5, s7, s9);
+                        s1 = peg$c570(s3, s5, s7, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -10710,12 +10739,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c569) {
-          s3 = peg$c569;
+        if (input.substr(peg$currPos, 7) === peg$c571) {
+          s3 = peg$c571;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c570); }
+          if (peg$silentFails === 0) { peg$fail(peg$c572); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -10739,7 +10768,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c568(s3, s5, s7, s9);
+                        s1 = peg$c570(s3, s5, s7, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -10799,12 +10828,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c571) {
-          s3 = peg$c571;
+        if (input.substr(peg$currPos, 7) === peg$c573) {
+          s3 = peg$c573;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c572); }
+          if (peg$silentFails === 0) { peg$fail(peg$c574); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -10824,7 +10853,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c573(s3, s5, s7);
+                    s1 = peg$c575(s3, s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -10932,7 +10961,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c574(s1);
+      s1 = peg$c576(s1);
     }
     s0 = s1;
 
@@ -10953,12 +10982,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c575) {
-          s3 = peg$c575;
+        if (input.substr(peg$currPos, 3) === peg$c577) {
+          s3 = peg$c577;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c576); }
+          if (peg$silentFails === 0) { peg$fail(peg$c578); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -11025,7 +11054,7 @@ function peg$parse(input, options) {
                           }
                           if (s12 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c577(s5, s7, s9, s11);
+                            s1 = peg$c579(s5, s7, s9, s11);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -11083,43 +11112,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9) === peg$c578) {
-      s1 = peg$c578;
+    if (input.substr(peg$currPos, 9) === peg$c580) {
+      s1 = peg$c580;
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c579); }
+      if (peg$silentFails === 0) { peg$fail(peg$c581); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 12) === peg$c580) {
-        s1 = peg$c580;
+      if (input.substr(peg$currPos, 12) === peg$c582) {
+        s1 = peg$c582;
         peg$currPos += 12;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c581); }
+        if (peg$silentFails === 0) { peg$fail(peg$c583); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c539) {
-          s1 = peg$c539;
+        if (input.substr(peg$currPos, 3) === peg$c541) {
+          s1 = peg$c541;
           peg$currPos += 3;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c540); }
+          if (peg$silentFails === 0) { peg$fail(peg$c542); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c582) {
-            s1 = peg$c582;
+          if (input.substr(peg$currPos, 7) === peg$c584) {
+            s1 = peg$c584;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c583); }
+            if (peg$silentFails === 0) { peg$fail(peg$c585); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c584(s1);
+      s1 = peg$c586(s1);
     }
     s0 = s1;
 
@@ -11130,52 +11159,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c585) {
-      s1 = peg$c585;
+    if (input.substr(peg$currPos, 6) === peg$c587) {
+      s1 = peg$c587;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c586); }
+      if (peg$silentFails === 0) { peg$fail(peg$c588); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c587) {
-        s1 = peg$c587;
+      if (input.substr(peg$currPos, 4) === peg$c589) {
+        s1 = peg$c589;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c588); }
+        if (peg$silentFails === 0) { peg$fail(peg$c590); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c589) {
-          s1 = peg$c589;
+        if (input.substr(peg$currPos, 4) === peg$c591) {
+          s1 = peg$c591;
           peg$currPos += 4;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c590); }
+          if (peg$silentFails === 0) { peg$fail(peg$c592); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 9) === peg$c591) {
-            s1 = peg$c591;
+          if (input.substr(peg$currPos, 9) === peg$c593) {
+            s1 = peg$c593;
             peg$currPos += 9;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c592); }
+            if (peg$silentFails === 0) { peg$fail(peg$c594); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 9) === peg$c593) {
-              s1 = peg$c593;
+            if (input.substr(peg$currPos, 9) === peg$c595) {
+              s1 = peg$c595;
               peg$currPos += 9;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c594); }
+              if (peg$silentFails === 0) { peg$fail(peg$c596); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 6) === peg$c595) {
-                s1 = peg$c595;
+              if (input.substr(peg$currPos, 6) === peg$c597) {
+                s1 = peg$c597;
                 peg$currPos += 6;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c596); }
+                if (peg$silentFails === 0) { peg$fail(peg$c598); }
               }
             }
           }
@@ -11184,7 +11213,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c597(s1);
+      s1 = peg$c599(s1);
     }
     s0 = s1;
 
@@ -11323,36 +11352,36 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = [];
             s6 = peg$currPos;
-            if (input.substr(peg$currPos, 8) === peg$c598) {
-              s7 = peg$c598;
+            if (input.substr(peg$currPos, 8) === peg$c600) {
+              s7 = peg$c600;
               peg$currPos += 8;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c599); }
+              if (peg$silentFails === 0) { peg$fail(peg$c601); }
             }
             if (s7 === peg$FAILED) {
-              if (input.substr(peg$currPos, 9) === peg$c600) {
-                s7 = peg$c600;
+              if (input.substr(peg$currPos, 9) === peg$c602) {
+                s7 = peg$c602;
                 peg$currPos += 9;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c601); }
+                if (peg$silentFails === 0) { peg$fail(peg$c603); }
               }
               if (s7 === peg$FAILED) {
-                if (input.substr(peg$currPos, 11) === peg$c602) {
-                  s7 = peg$c602;
+                if (input.substr(peg$currPos, 11) === peg$c604) {
+                  s7 = peg$c604;
                   peg$currPos += 11;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c603); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c605); }
                 }
                 if (s7 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 12) === peg$c604) {
-                    s7 = peg$c604;
+                  if (input.substr(peg$currPos, 12) === peg$c606) {
+                    s7 = peg$c606;
                     peg$currPos += 12;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c605); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c607); }
                   }
                 }
               }
@@ -11361,7 +11390,7 @@ function peg$parse(input, options) {
               s8 = peg$parse_();
               if (s8 !== peg$FAILED) {
                 peg$savedPos = s6;
-                s7 = peg$c606(s3, s7);
+                s7 = peg$c608(s3, s7);
                 s6 = s7;
               } else {
                 peg$currPos = s6;
@@ -11375,36 +11404,36 @@ function peg$parse(input, options) {
               while (s6 !== peg$FAILED) {
                 s5.push(s6);
                 s6 = peg$currPos;
-                if (input.substr(peg$currPos, 8) === peg$c598) {
-                  s7 = peg$c598;
+                if (input.substr(peg$currPos, 8) === peg$c600) {
+                  s7 = peg$c600;
                   peg$currPos += 8;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c599); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c601); }
                 }
                 if (s7 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 9) === peg$c600) {
-                    s7 = peg$c600;
+                  if (input.substr(peg$currPos, 9) === peg$c602) {
+                    s7 = peg$c602;
                     peg$currPos += 9;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c601); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c603); }
                   }
                   if (s7 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 11) === peg$c602) {
-                      s7 = peg$c602;
+                    if (input.substr(peg$currPos, 11) === peg$c604) {
+                      s7 = peg$c604;
                       peg$currPos += 11;
                     } else {
                       s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c603); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c605); }
                     }
                     if (s7 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 12) === peg$c604) {
-                        s7 = peg$c604;
+                      if (input.substr(peg$currPos, 12) === peg$c606) {
+                        s7 = peg$c606;
                         peg$currPos += 12;
                       } else {
                         s7 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c605); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c607); }
                       }
                     }
                   }
@@ -11413,7 +11442,7 @@ function peg$parse(input, options) {
                   s8 = peg$parse_();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s6;
-                    s7 = peg$c606(s3, s7);
+                    s7 = peg$c608(s3, s7);
                     s6 = s7;
                   } else {
                     peg$currPos = s6;
@@ -11437,7 +11466,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c607(s3, s5);
+                s1 = peg$c609(s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11481,12 +11510,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c608) {
-          s3 = peg$c608;
+        if (input.substr(peg$currPos, 4) === peg$c610) {
+          s3 = peg$c610;
           peg$currPos += 4;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c609); }
+          if (peg$silentFails === 0) { peg$fail(peg$c611); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -11552,12 +11581,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c608) {
-          s3 = peg$c608;
+        if (input.substr(peg$currPos, 4) === peg$c610) {
+          s3 = peg$c610;
           peg$currPos += 4;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c609); }
+          if (peg$silentFails === 0) { peg$fail(peg$c611); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -11579,7 +11608,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c610(s3, s5, s7);
+                      s1 = peg$c612(s3, s5, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -11635,12 +11664,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c611) {
-          s3 = peg$c611;
+        if (input.substr(peg$currPos, 2) === peg$c613) {
+          s3 = peg$c613;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c612); }
+          if (peg$silentFails === 0) { peg$fail(peg$c614); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -11673,12 +11702,12 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       s10 = peg$currPos;
-                      if (input.substr(peg$currPos, 8) === peg$c613) {
-                        s11 = peg$c613;
+                      if (input.substr(peg$currPos, 8) === peg$c615) {
+                        s11 = peg$c615;
                         peg$currPos += 8;
                       } else {
                         s11 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c614); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c616); }
                       }
                       if (s11 !== peg$FAILED) {
                         s12 = peg$parse_();
@@ -11706,7 +11735,7 @@ function peg$parse(input, options) {
                         }
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c615(s3, s5, s7, s9, s10);
+                          s1 = peg$c617(s3, s5, s7, s9, s10);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -11770,12 +11799,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 10) === peg$c616) {
-          s3 = peg$c616;
+        if (input.substr(peg$currPos, 10) === peg$c618) {
+          s3 = peg$c618;
           peg$currPos += 10;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c617); }
+          if (peg$silentFails === 0) { peg$fail(peg$c619); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -11797,7 +11826,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c618(s3, s5, s7);
+                      s1 = peg$c620(s3, s5, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -11919,7 +11948,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c619(s3, s5);
+                s1 = peg$c621(s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -11953,16 +11982,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c589) {
-      s1 = peg$c589;
+    if (input.substr(peg$currPos, 4) === peg$c591) {
+      s1 = peg$c591;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c590); }
+      if (peg$silentFails === 0) { peg$fail(peg$c592); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c620(s1);
+      s1 = peg$c622(s1);
     }
     s0 = s1;
 
@@ -11983,12 +12012,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c621) {
-          s3 = peg$c621;
+        if (input.substr(peg$currPos, 6) === peg$c623) {
+          s3 = peg$c623;
           peg$currPos += 6;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c622); }
+          if (peg$silentFails === 0) { peg$fail(peg$c624); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -12010,7 +12039,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c623(s3, s5, s7);
+                      s1 = peg$c625(s3, s5, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -12089,7 +12118,7 @@ function peg$parse(input, options) {
               s8 = peg$parse_();
               if (s8 !== peg$FAILED) {
                 peg$savedPos = s6;
-                s7 = peg$c624(s3, s7);
+                s7 = peg$c626(s3, s7);
                 s6 = s7;
               } else {
                 peg$currPos = s6;
@@ -12113,7 +12142,7 @@ function peg$parse(input, options) {
                 s8 = peg$parse_();
                 if (s8 !== peg$FAILED) {
                   peg$savedPos = s6;
-                  s7 = peg$c624(s3, s7);
+                  s7 = peg$c626(s3, s7);
                   s6 = s7;
                 } else {
                   peg$currPos = s6;
@@ -12232,28 +12261,28 @@ function peg$parse(input, options) {
   function peg$parsePAD_NUMERIC() {
     var s0;
 
-    if (input.substr(peg$currPos, 13) === peg$c625) {
-      s0 = peg$c625;
+    if (input.substr(peg$currPos, 13) === peg$c627) {
+      s0 = peg$c627;
       peg$currPos += 13;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c626); }
+      if (peg$silentFails === 0) { peg$fail(peg$c628); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 16) === peg$c627) {
-        s0 = peg$c627;
+      if (input.substr(peg$currPos, 16) === peg$c629) {
+        s0 = peg$c629;
         peg$currPos += 16;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c628); }
+        if (peg$silentFails === 0) { peg$fail(peg$c630); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 10) === peg$c629) {
-          s0 = peg$c629;
+        if (input.substr(peg$currPos, 10) === peg$c631) {
+          s0 = peg$c631;
           peg$currPos += 10;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c630); }
+          if (peg$silentFails === 0) { peg$fail(peg$c632); }
         }
       }
     }
@@ -12275,12 +12304,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c631) {
-          s3 = peg$c631;
+        if (input.substr(peg$currPos, 7) === peg$c633) {
+          s3 = peg$c633;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c632); }
+          if (peg$silentFails === 0) { peg$fail(peg$c634); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -12295,7 +12324,7 @@ function peg$parse(input, options) {
               s8 = peg$parse_();
               if (s8 !== peg$FAILED) {
                 peg$savedPos = s6;
-                s7 = peg$c624(s3, s7);
+                s7 = peg$c626(s3, s7);
                 s6 = s7;
               } else {
                 peg$currPos = s6;
@@ -12316,7 +12345,7 @@ function peg$parse(input, options) {
                 s8 = peg$parse_();
                 if (s8 !== peg$FAILED) {
                   peg$savedPos = s6;
-                  s7 = peg$c624(s3, s7);
+                  s7 = peg$c626(s3, s7);
                   s6 = s7;
                 } else {
                   peg$currPos = s6;
@@ -12381,30 +12410,30 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c633) {
-          s3 = peg$c633;
+        if (input.substr(peg$currPos, 6) === peg$c635) {
+          s3 = peg$c635;
           peg$currPos += 6;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c634); }
+          if (peg$silentFails === 0) { peg$fail(peg$c636); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c585) {
-              s5 = peg$c585;
+            if (input.substr(peg$currPos, 6) === peg$c587) {
+              s5 = peg$c587;
               peg$currPos += 6;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c586); }
+              if (peg$silentFails === 0) { peg$fail(peg$c588); }
             }
             if (s5 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c587) {
-                s5 = peg$c587;
+              if (input.substr(peg$currPos, 4) === peg$c589) {
+                s5 = peg$c589;
                 peg$currPos += 4;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c588); }
+                if (peg$silentFails === 0) { peg$fail(peg$c590); }
               }
             }
             if (s5 !== peg$FAILED) {
@@ -12419,7 +12448,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c635(s3, s5);
+                  s1 = peg$c637(s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -12477,20 +12506,20 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 7) === peg$c636) {
-              s5 = peg$c636;
+            if (input.substr(peg$currPos, 7) === peg$c638) {
+              s5 = peg$c638;
               peg$currPos += 7;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c637); }
+              if (peg$silentFails === 0) { peg$fail(peg$c639); }
             }
             if (s5 === peg$FAILED) {
-              if (input.substr(peg$currPos, 10) === peg$c638) {
-                s5 = peg$c638;
+              if (input.substr(peg$currPos, 10) === peg$c640) {
+                s5 = peg$c640;
                 peg$currPos += 10;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c639); }
+                if (peg$silentFails === 0) { peg$fail(peg$c641); }
               }
             }
             if (s5 !== peg$FAILED) {
@@ -12505,7 +12534,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c640(s3, s5);
+                  s1 = peg$c642(s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -12553,12 +12582,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 10) === peg$c641) {
-          s3 = peg$c641;
+        if (input.substr(peg$currPos, 10) === peg$c643) {
+          s3 = peg$c643;
           peg$currPos += 10;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c642); }
+          if (peg$silentFails === 0) { peg$fail(peg$c644); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -12570,7 +12599,7 @@ function peg$parse(input, options) {
               s8 = peg$parse_();
               if (s8 !== peg$FAILED) {
                 peg$savedPos = s6;
-                s7 = peg$c643(s3, s7);
+                s7 = peg$c645(s3, s7);
                 s6 = s7;
               } else {
                 peg$currPos = s6;
@@ -12588,7 +12617,7 @@ function peg$parse(input, options) {
                 s8 = peg$parse_();
                 if (s8 !== peg$FAILED) {
                   peg$savedPos = s6;
-                  s7 = peg$c643(s3, s7);
+                  s7 = peg$c645(s3, s7);
                   s6 = s7;
                 } else {
                   peg$currPos = s6;
@@ -12676,12 +12705,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c644) {
-          s3 = peg$c644;
+        if (input.substr(peg$currPos, 6) === peg$c646) {
+          s3 = peg$c646;
           peg$currPos += 6;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c645); }
+          if (peg$silentFails === 0) { peg$fail(peg$c647); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -12705,7 +12734,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c646(s3, s5, s7, s9);
+                        s1 = peg$c648(s3, s5, s7, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -12765,12 +12794,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c647) {
-          s3 = peg$c647;
+        if (input.substr(peg$currPos, 9) === peg$c649) {
+          s3 = peg$c649;
           peg$currPos += 9;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c648); }
+          if (peg$silentFails === 0) { peg$fail(peg$c650); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -12794,7 +12823,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c646(s3, s5, s7, s9);
+                        s1 = peg$c648(s3, s5, s7, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -12854,12 +12883,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c649) {
-          s3 = peg$c649;
+        if (input.substr(peg$currPos, 8) === peg$c651) {
+          s3 = peg$c651;
           peg$currPos += 8;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c650); }
+          if (peg$silentFails === 0) { peg$fail(peg$c652); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -12879,7 +12908,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c565(s3, s5, s7);
+                    s1 = peg$c567(s3, s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -12931,12 +12960,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c651) {
-          s3 = peg$c651;
+        if (input.substr(peg$currPos, 3) === peg$c653) {
+          s3 = peg$c653;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c652); }
+          if (peg$silentFails === 0) { peg$fail(peg$c654); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -12966,7 +12995,7 @@ function peg$parse(input, options) {
                             }
                             if (s13 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c653(s5, s7, s9, s11);
+                              s1 = peg$c655(s5, s7, s9, s11);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -13038,12 +13067,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c654) {
-          s3 = peg$c654;
+        if (input.substr(peg$currPos, 7) === peg$c656) {
+          s3 = peg$c656;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c655); }
+          if (peg$silentFails === 0) { peg$fail(peg$c657); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -13067,7 +13096,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c656(s3, s5, s7, s9);
+                        s1 = peg$c658(s3, s5, s7, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -13127,12 +13156,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c657) {
-          s3 = peg$c657;
+        if (input.substr(peg$currPos, 7) === peg$c659) {
+          s3 = peg$c659;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c658); }
+          if (peg$silentFails === 0) { peg$fail(peg$c660); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -13156,7 +13185,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c656(s3, s5, s7, s9);
+                        s1 = peg$c658(s3, s5, s7, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -13216,12 +13245,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c659) {
-          s3 = peg$c659;
+        if (input.substr(peg$currPos, 7) === peg$c661) {
+          s3 = peg$c661;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c660); }
+          if (peg$silentFails === 0) { peg$fail(peg$c662); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -13241,7 +13270,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c661(s3, s5, s7);
+                    s1 = peg$c663(s3, s5, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -13293,12 +13322,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c662) {
-          s3 = peg$c662;
+        if (input.substr(peg$currPos, 7) === peg$c664) {
+          s3 = peg$c664;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c663); }
+          if (peg$silentFails === 0) { peg$fail(peg$c665); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -13370,7 +13399,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c664(s3, s5, s7, s9);
+                        s1 = peg$c666(s3, s5, s7, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -13486,7 +13515,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c574(s1);
+      s1 = peg$c576(s1);
     }
     s0 = s1;
 
@@ -13507,12 +13536,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c665) {
-          s3 = peg$c665;
+        if (input.substr(peg$currPos, 6) === peg$c667) {
+          s3 = peg$c667;
           peg$currPos += 6;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c666); }
+          if (peg$silentFails === 0) { peg$fail(peg$c668); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -13649,12 +13678,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c667) {
-          s3 = peg$c667;
+        if (input.substr(peg$currPos, 6) === peg$c669) {
+          s3 = peg$c669;
           peg$currPos += 6;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c668); }
+          if (peg$silentFails === 0) { peg$fail(peg$c670); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -13676,7 +13705,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c669(s3, s5, s7);
+                      s1 = peg$c671(s3, s5, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -13732,12 +13761,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c670) {
-          s3 = peg$c670;
+        if (input.substr(peg$currPos, 4) === peg$c672) {
+          s3 = peg$c672;
           peg$currPos += 4;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c671); }
+          if (peg$silentFails === 0) { peg$fail(peg$c673); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -13793,52 +13822,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c672) {
-      s1 = peg$c672;
+    if (input.substr(peg$currPos, 4) === peg$c674) {
+      s1 = peg$c674;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c673); }
+      if (peg$silentFails === 0) { peg$fail(peg$c675); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 8) === peg$c674) {
-        s1 = peg$c674;
+      if (input.substr(peg$currPos, 8) === peg$c676) {
+        s1 = peg$c676;
         peg$currPos += 8;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c675); }
+        if (peg$silentFails === 0) { peg$fail(peg$c677); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 12) === peg$c676) {
-          s1 = peg$c676;
+        if (input.substr(peg$currPos, 12) === peg$c678) {
+          s1 = peg$c678;
           peg$currPos += 12;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c677); }
+          if (peg$silentFails === 0) { peg$fail(peg$c679); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c678) {
-            s1 = peg$c678;
+          if (input.substr(peg$currPos, 3) === peg$c680) {
+            s1 = peg$c680;
             peg$currPos += 3;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c679); }
+            if (peg$silentFails === 0) { peg$fail(peg$c681); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 7) === peg$c680) {
-              s1 = peg$c680;
+            if (input.substr(peg$currPos, 7) === peg$c682) {
+              s1 = peg$c682;
               peg$currPos += 7;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c681); }
+              if (peg$silentFails === 0) { peg$fail(peg$c683); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c682) {
-                s1 = peg$c682;
+              if (input.substr(peg$currPos, 5) === peg$c684) {
+                s1 = peg$c684;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c683); }
+                if (peg$silentFails === 0) { peg$fail(peg$c685); }
               }
             }
           }
@@ -13847,7 +13876,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c684(s1);
+      s1 = peg$c686(s1);
     }
     s0 = s1;
 
@@ -13855,77 +13884,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parsewidth() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c0;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c1); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c685) {
-          s3 = peg$c685;
-          peg$currPos += 5;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c686); }
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parsenumber();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parse_();
-              if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c5;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c6); }
-                }
-                if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c202(s3, s5);
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseangle() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
@@ -13996,6 +13954,77 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseangle() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 40) {
+      s1 = peg$c0;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c1); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 5) === peg$c689) {
+          s3 = peg$c689;
+          peg$currPos += 5;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c690); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parsenumber();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse_();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c5;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c202(s3, s5);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parsemid() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
@@ -14010,12 +14039,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c689) {
-          s3 = peg$c689;
+        if (input.substr(peg$currPos, 3) === peg$c691) {
+          s3 = peg$c691;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c690); }
+          if (peg$silentFails === 0) { peg$fail(peg$c692); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -14081,12 +14110,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c691) {
-          s3 = peg$c691;
+        if (input.substr(peg$currPos, 5) === peg$c693) {
+          s3 = peg$c693;
           peg$currPos += 5;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c692); }
+          if (peg$silentFails === 0) { peg$fail(peg$c694); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -14149,7 +14178,7 @@ function peg$parse(input, options) {
         s3 = peg$parsenumber();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c693(s1, s3);
+          s1 = peg$c695(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -14181,20 +14210,20 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c691) {
-          s3 = peg$c691;
+        if (input.substr(peg$currPos, 5) === peg$c693) {
+          s3 = peg$c693;
           peg$currPos += 5;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c692); }
+          if (peg$silentFails === 0) { peg$fail(peg$c694); }
         }
         if (s3 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c694) {
-            s3 = peg$c694;
+          if (input.substr(peg$currPos, 6) === peg$c696) {
+            s3 = peg$c696;
             peg$currPos += 6;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c695); }
+            if (peg$silentFails === 0) { peg$fail(peg$c697); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -14213,7 +14242,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c696(s3, s5);
+                  s1 = peg$c698(s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -14261,12 +14290,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c694) {
-          s3 = peg$c694;
+        if (input.substr(peg$currPos, 6) === peg$c696) {
+          s3 = peg$c696;
           peg$currPos += 6;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c695); }
+          if (peg$silentFails === 0) { peg$fail(peg$c697); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -14332,12 +14361,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c697) {
-          s3 = peg$c697;
+        if (input.substr(peg$currPos, 3) === peg$c699) {
+          s3 = peg$c699;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c698); }
+          if (peg$silentFails === 0) { peg$fail(peg$c700); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -14403,12 +14432,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c651) {
-          s3 = peg$c651;
+        if (input.substr(peg$currPos, 3) === peg$c653) {
+          s3 = peg$c653;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c652); }
+          if (peg$silentFails === 0) { peg$fail(peg$c654); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -14461,7 +14490,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c699(s3, s5);
+                s1 = peg$c701(s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -14505,12 +14534,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c700) {
-          s3 = peg$c700;
+        if (input.substr(peg$currPos, 2) === peg$c702) {
+          s3 = peg$c702;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c701); }
+          if (peg$silentFails === 0) { peg$fail(peg$c703); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -14576,12 +14605,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c702) {
-          s3 = peg$c702;
+        if (input.substr(peg$currPos, 5) === peg$c704) {
+          s3 = peg$c704;
           peg$currPos += 5;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c703); }
+          if (peg$silentFails === 0) { peg$fail(peg$c705); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -14651,7 +14680,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c704(s3, s5, s7);
+                      s1 = peg$c706(s3, s5, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -14707,12 +14736,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c705) {
-          s3 = peg$c705;
+        if (input.substr(peg$currPos, 7) === peg$c707) {
+          s3 = peg$c707;
           peg$currPos += 7;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c706); }
+          if (peg$silentFails === 0) { peg$fail(peg$c708); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -14730,7 +14759,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c707(s5);
+                  s1 = peg$c709(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -14778,36 +14807,36 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c611) {
-          s3 = peg$c611;
+        if (input.substr(peg$currPos, 2) === peg$c613) {
+          s3 = peg$c613;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c612); }
+          if (peg$silentFails === 0) { peg$fail(peg$c614); }
         }
         if (s3 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c621) {
-            s3 = peg$c621;
+          if (input.substr(peg$currPos, 6) === peg$c623) {
+            s3 = peg$c623;
             peg$currPos += 6;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c622); }
+            if (peg$silentFails === 0) { peg$fail(peg$c624); }
           }
           if (s3 === peg$FAILED) {
-            if (input.substr(peg$currPos, 5) === peg$c708) {
-              s3 = peg$c708;
+            if (input.substr(peg$currPos, 5) === peg$c710) {
+              s3 = peg$c710;
               peg$currPos += 5;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c709); }
+              if (peg$silentFails === 0) { peg$fail(peg$c711); }
             }
             if (s3 === peg$FAILED) {
-              if (input.substr(peg$currPos, 6) === peg$c710) {
-                s3 = peg$c710;
+              if (input.substr(peg$currPos, 6) === peg$c712) {
+                s3 = peg$c712;
                 peg$currPos += 6;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c711); }
+                if (peg$silentFails === 0) { peg$fail(peg$c713); }
               }
             }
           }
@@ -14828,7 +14857,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c712(s3, s5);
+                  s1 = peg$c714(s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -14876,12 +14905,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c713) {
-          s3 = peg$c713;
+        if (input.substr(peg$currPos, 3) === peg$c715) {
+          s3 = peg$c715;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c714); }
+          if (peg$silentFails === 0) { peg$fail(peg$c716); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -14907,7 +14936,7 @@ function peg$parse(input, options) {
                         }
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c715(s3, s5, s7, s9);
+                          s1 = peg$c717(s3, s5, s7, s9);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -14962,11 +14991,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c716;
+      s1 = peg$c448;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c717); }
+      if (peg$silentFails === 0) { peg$fail(peg$c449); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -14977,11 +15006,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c716;
+          s3 = peg$c448;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c717); }
+          if (peg$silentFails === 0) { peg$fail(peg$c449); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -15051,11 +15080,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c716;
+      s2 = peg$c448;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c717); }
+      if (peg$silentFails === 0) { peg$fail(peg$c449); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
@@ -15210,11 +15239,11 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c716;
+        s0 = peg$c448;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c717); }
+        if (peg$silentFails === 0) { peg$fail(peg$c449); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
@@ -16311,7 +16340,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c684(s1);
+      s1 = peg$c686(s1);
     }
     s0 = s1;
 
@@ -16485,7 +16514,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c684(s1);
+      s1 = peg$c686(s1);
     }
     s0 = s1;
 

--- a/src/module.pegjs
+++ b/src/module.pegjs
@@ -614,7 +614,7 @@ placed  = "placed"{ return { type: "placed", value: { type: "boolean", value: tr
 //     }
 // }
 
-layer = "(" _ type: "layer" _ value:(LAYER / symbol) _ ")" {
+layer = "(" _ type: "layer" _ "\""? value:(LAYER / symbol) "\""? _ ")" {
     return { type, value }
 }
 


### PR DESCRIPTION
# Impact

* Allows us to parse modules that have been saved with a recent KiCad version.

# Description
* I missed this case and encountered it when verifying the changes against the existing file. Opening and saving a footprint adds quotes to the `layer` expression that the parser wasn't stripping. This lead to the layer value being  interpreted as a symbol and returning `"\"F.Cu\""` which isn't supported by Flux. 

By allowing for optional strings around the layer we parse the string as a layer correctly.
