### PR TITLE
rebuild parser

### DIFF
--- a/src/module-parser.js
+++ b/src/module-parser.js
@@ -1275,10 +1275,11 @@ function peg$parse(input, options) {
                   value: [ value, ...values.map(x => x[0])]
               }
           },
-      peg$c752 = /^[^ ();'"\n]/,
-      peg$c753 = peg$classExpectation([" ", "(", ")", ";", "'", "\"", "\n"], true, false),
+      peg$c752 = /^[^ ();'\n]/,
+      peg$c753 = peg$classExpectation([" ", "(", ")", ";", "'", "\n"], true, false),
       peg$c754 = function(value) {
-             return { type:"string", value: "SYM" + value }
+             return {type:"string",value}
+
          },
       peg$c755 = peg$otherExpectation("whitespace"),
       peg$c756 = /^[ \t\n\r]/,


### PR DESCRIPTION
Was getting an extra "SYM" prefix on the parsed name
e.g. for this example file: https://drive.google.com/file/d/1PWh14H4MKNH4wg7Ic7QoLuNNB5y8uLcz/view?usp=drive_link

so I just reran `build` and this branch now seems to work